### PR TITLE
Don't treat port messages as a closed channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed an issue where the `gleam/otp/process.bare_message_receiver` function ignored messages from ports
+
 ## v0.1.3 - 2020-11-07
 
 - The `gleam/otp/actor.ErlangStartResult` type has been re-added.

--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -99,7 +99,7 @@ run_receiver(Receiver, Timeout) ->
     OpenChannels = currently_open_channels(),
     receive
         % Message on closed channels are discarded
-        {Ref, _} when not is_map_key(Ref, OpenChannels) ->
+        {Ref, _} when is_reference(Ref) andalso (not is_map_key(Ref, OpenChannels)) ->
             % TODO: shrink timeout if time has passed
             run_receiver(Receiver, Timeout);
 

--- a/test/gleam/otp/process_test.gleam
+++ b/test/gleam/otp/process_test.gleam
@@ -1,4 +1,5 @@
 import gleam/otp/process.{Normal}
+import gleam/otp/port.{Port}
 import gleam/should
 import gleam/io
 import gleam/result
@@ -104,6 +105,16 @@ pub fn bare_receive_test() {
   receiver
   |> process.receive(0)
   |> should.equal(Ok(0))
+}
+
+pub fn bare_receive_port_test() {
+  // Generate a port message
+  let port = open_port(Spawn("echo -n hello"), [])
+
+  // The channel recieves the stdout from the port
+  process.bare_message_receiver()
+  |> process.receive(100)
+  |> should.be_ok()
 }
 
 pub fn run_receiver_forever_test() {
@@ -323,3 +334,15 @@ pub fn map_sender_test() {
   |> process.receive(0)
   |> should.equal(Ok([3]))
 }
+
+type PortName {
+  Spawn(command: String)
+  SpawnExecutable(command: String)
+}
+
+type PortSettings {
+  ExitStatus
+}
+
+external fn open_port(PortName, List(PortSettings)) -> Port =
+  "erlang" "open_port"


### PR DESCRIPTION
I went for a very minimal fix as a first pass, just making sure port messages can received with `bare_message_receiver()`

