### PR TITLE
Remove compiler warnings when compiled with 0.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
           otp-version: 22.2
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.12.0-rc3
+          gleam-version: 0.14.0
       - run: rebar3 install_deps
       - run: rebar3 eunit

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -1,5 +1,5 @@
 import gleam/otp/process.{
-  Abnormal, DebugState, ExitReason, GetState, GetStatus, Mode, Normal, Pid, ProcessDown,
+  DebugState, ExitReason, GetState, GetStatus, Mode, Pid, ProcessDown,
   Receiver, Resume, Running, Sender, Suspend, Suspended, SystemMessage,
 }
 import gleam/io

--- a/src/gleam/otp/process.gleam
+++ b/src/gleam/otp/process.gleam
@@ -2,7 +2,6 @@ import gleam/atom
 import gleam/result
 import gleam/atom.{Atom}
 import gleam/dynamic.{Dynamic}
-import gleam/option.{None}
 import gleam/otp/port.{Port}
 import gleam/function
 import gleam/option.{None, Option, Some}

--- a/src/gleam/otp/process.gleam
+++ b/src/gleam/otp/process.gleam
@@ -2,7 +2,7 @@ import gleam/atom
 import gleam/result
 import gleam/atom.{Atom}
 import gleam/dynamic.{Dynamic}
-import gleam/otp/port.{Port}
+import gleam/otp/port
 import gleam/function
 import gleam/option.{None, Option, Some}
 
@@ -184,7 +184,7 @@ type PortMonitorFlag {
   Port
 }
 
-external fn erlang_monitor_port(PortMonitorFlag, Port) -> Reference =
+external fn erlang_monitor_port(PortMonitorFlag, port.Port) -> Reference =
   "erlang" "monitor"
 
 // TODO: test
@@ -197,7 +197,7 @@ external fn erlang_monitor_port(PortMonitorFlag, Port) -> Reference =
 /// Closing the channel with `close_channels` demonitors the port and flushes
 /// any monitor message for this channel from the message inbox.
 ///
-pub fn monitor_port(port: Port) -> Receiver(PortDown) {
+pub fn monitor_port(port: port.Port) -> Receiver(PortDown) {
   let reference = erlang_monitor_port(Port, port)
   new_receiver(tuple(Port, reference))
 }
@@ -211,7 +211,7 @@ pub type ProcessDown {
 /// A message received when a monitored port exits.
 ///
 pub type PortDown {
-  PortDown(port: Port, reason: Dynamic)
+  PortDown(port: port.Port, reason: Dynamic)
 }
 
 /// Receive a message from one of the channels in a receiver.

--- a/src/gleam/otp/supervisor.gleam
+++ b/src/gleam/otp/supervisor.gleam
@@ -324,8 +324,8 @@ fn handle_exit(pid: process.Pid, state: State(a)) -> actor.Next(State(a)) {
 
 fn loop(message: Message, state: State(argument)) -> actor.Next(State(argument)) {
   case message {
-    Exit(process.Exit(pid: pid, ..)) | RetryRestart(pid) ->
-      handle_exit(pid, state)
+    Exit(process.Exit(pid: pid, ..)) -> handle_exit(pid, state)
+    RetryRestart(pid) -> handle_exit(pid, state)
   }
 }
 

--- a/test/gleam/otp/process_test.gleam
+++ b/test/gleam/otp/process_test.gleam
@@ -109,7 +109,7 @@ pub fn bare_receive_test() {
 
 pub fn bare_receive_port_test() {
   // Generate a port message
-  let _port = open_port(Spawn("gleam --version"), [])
+  let _port = open_port(Spawn("gleam --version"), [ExitStatus])
 
   // The channel recieves the stdout from the port
   process.bare_message_receiver()

--- a/test/gleam/otp/process_test.gleam
+++ b/test/gleam/otp/process_test.gleam
@@ -1,11 +1,11 @@
-import gleam/otp/process.{Normal}
+import gleam/otp/process
 import gleam/otp/port.{Port}
 import gleam/should
 import gleam/io
 import gleam/result
 import gleam/atom
 import gleam/dynamic
-import gleam/option.{Some}
+import gleam/option
 
 external fn sleep(Int) -> Nil =
   "timer" "sleep"


### PR DESCRIPTION
Removing compiler warnings from gleam/otp when compiled with gleam 0.14.

Some comments:

* The changes in `supervisor.gleam` is due to a bug (gleam-lang/gleam#989)
* The problem with unused warning for import `gleam/opt/port.{Port}` might mask another problem. `Port` is used as a constructor in another type in the module but it is actually `port.Port` that should be used (I think). I'd expect the compiler to fail here because of ambiguous use of types. I worked around the warning by using the type explicitly
* I am unsure of the changes `process_test.gleam` relating to `ExitStatus`. As a quick workaround I add the `ExitStatus` to the `open_port` function. It passes the unit tests but I don't know if there are any side effects. The `ExitStatus` flags makes the port send an exit status command to the port process when the external command exits. An alternative could be to remove the `PortSetting` type completely and just send an empty list.  To some degree I don't know if I agree with the warning as it is quite nice to be able to document all the options in a type even if you are not using them. Perhaps it doesn't matter much for a test module and that you normally would use a public type in this case.

I've done the changes in separate commits based on the comments above, if anything need amending.