### PR TITLE
Add pid_from_dynamic to process module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `gleam/otp/process` module gains the `pid_from_dynamic` function.
+
 ## v0.3.1 - 2022-01-07
 
 - Updated for Gleam v0.19.0.

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.18"
+gleam_stdlib = "~> 0.19"
 gleam_erlang = "~> 0.2"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "B183BA07519354B4C27AD7F000E6CC8DF4F1B853FB940EC84E14F907EFFBA777" },
-  { name = "gleam_stdlib", version = "0.18.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2938F996BBB25D75E973226846CDDFA33AB5590AFC8A9D043A356EA85272510D" },
-  { name = "gleeunit", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "E8FDD4E31E0BBB87F625B0BB4DEABDE780180F1C2B15A4534442823066468638" },
+  { name = "gleam_erlang", version = "0.9.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "5AB10E3E0AF2956A035559F70944F6DEB7AFD6A8295171E5BBEB6831AECA3A47" },
+  { name = "gleam_stdlib", version = "0.19.3", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CA579C2FF0621E93FF6EFEF61BAFFCF0505732BA073F616E28878042F1A1F401" },
+  { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
 ]
 
 [requirements]
 gleam_erlang = "~> 0.2"
-gleam_stdlib = "~> 0.18"
+gleam_stdlib = "~> 0.19"
 gleeunit = "~> 0.1"

--- a/src/gleam/otp/process.gleam
+++ b/src/gleam/otp/process.gleam
@@ -1,7 +1,7 @@
 import gleam/erlang/atom
 import gleam/result
 import gleam/erlang/atom.{Atom}
-import gleam/dynamic.{Dynamic}
+import gleam/dynamic.{DecodeError, Dynamic}
 import gleam/otp/port
 import gleam/function
 import gleam/option.{None, Option, Some}
@@ -117,7 +117,7 @@ pub fn pid(sender: Sender(msg)) -> Pid {
 /// Attempt to parse a pid from some dynamic data
 ///
 /// This may be useful if you receive a pid in a message from an Erlang process.
-pub external fn pid_from_dynamic(dynamic : Dynamic) -> Result(Pid, Nil) =
+pub external fn pid_from_dynamic(Dynamic) -> Result(Pid, List(DecodeError)) =
   "gleam_otp_external" "pid_from_dynamic"
 
 /// Send a message over a channel.

--- a/src/gleam/otp/process.gleam
+++ b/src/gleam/otp/process.gleam
@@ -114,6 +114,12 @@ pub fn pid(sender: Sender(msg)) -> Pid {
   sender.pid
 }
 
+/// Attempt to parse a pid from some dynamic data
+///
+/// This may be useful if you receive a pid in a message from an Erlang process.
+pub external fn pid_from_dynamic(dynamic : Dynamic) -> Result(Pid, Nil) =
+  "gleam_otp_external" "pid_from_dynamic"
+
 /// Send a message over a channel.
 ///
 /// This function always succeeds, even if the receiving process has shut down

--- a/src/gleam/otp/process.gleam
+++ b/src/gleam/otp/process.gleam
@@ -114,7 +114,7 @@ pub fn pid(sender: Sender(msg)) -> Pid {
   sender.pid
 }
 
-/// Attempt to parse a pid from some dynamic data
+/// Attempt to parse a pid from some dynamic data.
 ///
 /// This may be useful if you receive a pid in a message from an Erlang process.
 pub external fn pid_from_dynamic(Dynamic) -> Result(Pid, List(DecodeError)) =

--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -9,6 +9,9 @@
          map_receiver/2, stop_trapping_exits/0, system_receiver/0,
          application_stopped/0]).
 
+% Pids
+-export([pid_from_dynamic/1]).
+
 % import Gleam records
 
 -include_lib("gleam_otp/include/gleam@otp@process_Sender.hrl").
@@ -215,3 +218,11 @@ process_status(Status) ->
 
 application_stopped() ->
     ok.
+
+% Pids 
+
+pid_from_dynamic(Dynamic) ->
+    case is_pid(Dynamic) of
+        true -> {ok, Dynamic};
+        false -> {error, nil}
+    end.

--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -224,5 +224,5 @@ application_stopped() ->
 pid_from_dynamic(Dynamic) ->
     case is_pid(Dynamic) of
         true -> {ok, Dynamic};
-        false -> {error, nil}
+        false -> {error, [{decode_error, <<"Pid">>, gleam@dynamic:classify(Dynamic), []}]}
     end.

--- a/test/gleam/otp/process_test.gleam
+++ b/test/gleam/otp/process_test.gleam
@@ -357,5 +357,7 @@ pub fn dynamic_is_not_pid_test() {
   let not_pid = "ceci n'est pas un pid"
   let dynamic = dynamic.from(not_pid)
   process.pid_from_dynamic(dynamic)
-  |> should.equal(Error(Nil))
+  |> should.equal(Error([
+    dynamic.DecodeError(expected: "Pid", found: "String", path: []),
+  ]))
 }

--- a/test/gleam/otp/process_test.gleam
+++ b/test/gleam/otp/process_test.gleam
@@ -345,3 +345,17 @@ type PortSettings {
 
 external fn open_port(PortName, List(PortSettings)) -> Port =
   "erlang" "open_port"
+
+pub fn dynamic_is_pid_test() {
+  let pid = process.start(fn() { Nil })
+  let dynamic = dynamic.from(pid)
+  process.pid_from_dynamic(dynamic)
+  |> should.equal(Ok(pid))
+}
+
+pub fn dynamic_is_not_pid_test() {
+  let not_pid = "ceci n'est pas un pid"
+  let dynamic = dynamic.from(not_pid)
+  process.pid_from_dynamic(dynamic)
+  |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
As discussed a couple of days ago on Discord, I thought I would have a go at adding a `pid_from_dynamic` function to the `process` module. I think this is a handy function for certain use cases, for example if you have an Erlang or Elixir process that sends its own pid in a message to a Gleam actor, and you want to reply to it using `process.untyped_send`.

You mentioned that you would prefer to write the decoder in Erlang, so I had a go at that - it's the first Erlang I've ever written, so apologies if there are any blunders. I wrote a couple of tests and they seem to pass, so hopefully it's ok.

This my second pull request on any project ever, so apologies if I have done anything stupid :)