### PR TITLE
task.await_forever and task.try_await_forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The `gleam/otp/process` module gains the `pid_from_dynamic` function.
+- The `gleam/otp/task` module gains the `await_forever` and `try_await_forever` functions.
 
 ## v0.3.1 - 2022-01-07
 

--- a/src/gleam/otp/task.gleam
+++ b/src/gleam/otp/task.gleam
@@ -117,7 +117,6 @@ pub fn await(task: Task(value), timeout: Int) -> value {
   value
 }
 
-// TODO: test
 /// Wait endlessly for the value computed by a task.
 ///
 /// Be Careful! This function does not return until there is a value to
@@ -141,7 +140,6 @@ pub fn try_await_forever(task: Task(value)) -> Result(value, AwaitError) {
   }
 }
 
-// TODO: test
 /// Wait endlessly for the value computed by a task.
 ///
 /// Be Careful! Like `try_await_forever`, this function does not return until there is a value to

--- a/src/gleam/otp/task.gleam
+++ b/src/gleam/otp/task.gleam
@@ -116,3 +116,40 @@ pub fn await(task: Task(value), timeout: Int) -> value {
   assert Ok(value) = try_await(task, timeout)
   value
 }
+
+// TODO: test
+/// Wait endlessly for the value computed by a task.
+///
+/// Be Careful! This function does not return until there is a value to
+/// receive. If a value is not received then the process will be stuck waiting
+/// forever.
+///
+pub fn try_await_forever(task: Task(value)) -> Result(value, AwaitError) {
+  assert_owner(task)
+  case process.receive_forever(task.receiver) {
+    // The task process has sent back a value
+    Chan(x) -> {
+      process.close_channels(task.receiver)
+      Ok(x)
+    }
+
+    // The task process crashed without sending a value
+    Mon(process.ProcessDown(reason: reason, ..)) -> {
+      process.close_channels(task.receiver)
+      Error(Exit(reason))
+    }
+  }
+}
+
+// TODO: test
+/// Wait endlessly for the value computed by a task.
+///
+/// Be Careful! Like `try_await_forever`, this function does not return until there is a value to
+/// receive.
+///
+/// If the task process crashes then this function crashes.
+///
+pub fn await_forever(task: Task(value)) -> value {
+  assert Ok(value) = try_await_forever(task)
+  value
+}

--- a/test/gleam/otp/task_test.gleam
+++ b/test/gleam/otp/task_test.gleam
@@ -5,14 +5,14 @@ import gleam/otp/process
 external fn sleep(Int) -> Nil =
   "timer" "sleep"
 
-pub fn async_await_test() {
-  let work = fn(x) {
-    fn() {
-      sleep(15)
-      x
-    }
+fn work(x) {
+  fn() {
+    sleep(15)
+    x
   }
+}
 
+pub fn async_await_test() {
   // Spawn 3 tasks, performing 45ms work collectively
   let t1 = task.async(work(1))
   let t2 = task.async(work(2))
@@ -26,16 +26,41 @@ pub fn async_await_test() {
   task.try_await(t3, 5)
   |> should.equal(Ok(3))
 
+  // Assert awaiting on previously retrieved tasks returns an error 
+  assert Error(task.Exit(_)) = task.try_await(t1, 35)
+  assert Error(task.Exit(_)) = task.try_await(t2, 35)
+  assert Error(task.Exit(_)) = task.try_await(t3, 35)
+}
+
+pub fn asyn_await_forever_test() {
+  // Spawn 3 tasks, performing 45ms work collectively
+  let t1 = task.async(work(1))
+  let t2 = task.async(work(2))
+  let t3 = task.async(work(3))
+
+  // Assert they run concurrently (not caring how long they take)
+  task.try_await_forever(t1)
+  |> should.equal(Ok(1))
+  task.try_await_forever(t2)
+  |> should.equal(Ok(2))
+  task.try_await_forever(t3)
+  |> should.equal(Ok(3))
+
+  // Assert awaiting on previously retrieved tasks returns an error 
+  assert Error(task.Exit(_)) = task.try_await_forever(t1)
+  assert Error(task.Exit(_)) = task.try_await_forever(t2)
+  assert Error(task.Exit(_)) = task.try_await_forever(t3)
+
   //  Spawn 3 more tasks, performing 45ms work collectively
   let t4 = task.async(work(4))
   let t5 = task.async(work(5))
   let t6 = task.async(work(6))
 
   // Assert they run concurrently (not caring how long they take)
-  task.try_await_forever(t4)
-  |> should.equal(Ok(4))
-  task.try_await_forever(t5)
-  |> should.equal(Ok(5))
-  task.try_await_forever(t6)
-  |> should.equal(Ok(6))
+  task.await_forever(t4)
+  |> should.equal(4)
+  task.await_forever(t5)
+  |> should.equal(5)
+  task.await_forever(t6)
+  |> should.equal(6)
 }

--- a/test/gleam/otp/task_test.gleam
+++ b/test/gleam/otp/task_test.gleam
@@ -25,4 +25,17 @@ pub fn async_await_test() {
   |> should.equal(Ok(2))
   task.try_await(t3, 5)
   |> should.equal(Ok(3))
+
+  //  Spawn 3 more tasks, performing 45ms work collectively
+  let t4 = task.async(work(4))
+  let t5 = task.async(work(5))
+  let t6 = task.async(work(6))
+
+  // Assert they run concurrently (not caring how long they take)
+  task.try_await_forever(t4)
+  |> should.equal(Ok(4))
+  task.try_await_forever(t5)
+  |> should.equal(Ok(5))
+  task.try_await_forever(t6)
+  |> should.equal(Ok(6))
 }


### PR DESCRIPTION
Noticed these were missing but that there is a `process.receive_forever` so I figured It might be worth including these