### PR TITLE
Unmonitor task when done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.0 - Unreleased
 
 - Updated to use the process module in the `gleam_erlang` library`.
+- Fixed bug: tasks are now unmonitored by their parent after completion.
 
 ## v0.4.0 - 2022-04-16
 

--- a/test/gleam/otp/task_test.gleam
+++ b/test/gleam/otp/task_test.gleam
@@ -1,5 +1,5 @@
 import gleeunit/should
-import gleam/otp/task
+import gleam/otp/task.{Timeout}
 
 external fn sleep(Int) -> Nil =
   "timer" "sleep"
@@ -25,10 +25,11 @@ pub fn async_await_test() {
   task.try_await(t3, 5)
   |> should.equal(Ok(3))
 
-  // Assert awaiting on previously retrieved tasks returns an error 
-  assert Error(task.Exit(_)) = task.try_await(t1, 35)
-  assert Error(task.Exit(_)) = task.try_await(t2, 35)
-  assert Error(task.Exit(_)) = task.try_await(t3, 35)
+  // Assert awaiting on previously retrieved tasks returns an error
+  // An already finished task will always time out! 
+  assert Error(Timeout) = task.try_await(t1, 35)
+  assert Error(Timeout) = task.try_await(t2, 35)
+  assert Error(Timeout) = task.try_await(t3, 35)
 }
 
 pub fn async_await_forever_test() {
@@ -44,11 +45,6 @@ pub fn async_await_forever_test() {
   |> should.equal(Ok(2))
   task.try_await_forever(t3)
   |> should.equal(Ok(3))
-
-  // Assert awaiting on previously retrieved tasks returns an error 
-  assert Error(task.Exit(_)) = task.try_await_forever(t1)
-  assert Error(task.Exit(_)) = task.try_await_forever(t2)
-  assert Error(task.Exit(_)) = task.try_await_forever(t3)
 
   //  Spawn 3 more tasks, performing 45ms work collectively
   let t4 = task.async(work(4))

--- a/test/gleam/otp/task_test.gleam
+++ b/test/gleam/otp/task_test.gleam
@@ -4,11 +4,14 @@ import gleam/otp/actor.{Continue}
 import gleam/erlang/process
 import gleam/otp/system
 
-type Item {
+type MessageQueueLen {
   MessageQueueLen
 }
 
-external fn process_info(pid: process.Pid, item: Item) -> #(Item, Int) =
+external fn process_info(
+  pid: process.Pid,
+  length: MessageQueueLen,
+) -> #(MessageQueueLen, Int) =
   "erlang" "process_info"
 
 external fn sleep(Int) -> Nil =

--- a/test/gleam/otp/task_test.gleam
+++ b/test/gleam/otp/task_test.gleam
@@ -31,7 +31,7 @@ pub fn async_await_test() {
   assert Error(task.Exit(_)) = task.try_await(t3, 35)
 }
 
-pub fn asyn_await_forever_test() {
+pub fn async_await_forever_test() {
   // Spawn 3 tasks, performing 45ms work collectively
   let t1 = task.async(work(1))
   let t2 = task.async(work(2))

--- a/test/gleam_otp_test_external.erl
+++ b/test/gleam_otp_test_external.erl
@@ -1,0 +1,12 @@
+-module(gleam_otp_test_external).
+
+-export([flush/0, get_message_queue_length/1]).
+
+flush() ->
+    receive _ -> flush()
+    after 0 -> nil
+    end.
+
+get_message_queue_length(Pid) ->
+  {_, Length} = process_info(Pid, message_queue_len),
+  Length.


### PR DESCRIPTION
Resolves: #39

- [x] Add monitor to Task type 
- [x] Add `process.demonitor_process(task.monitor)` to `try_await` and `try_await_forever`
- [x] Change tests to expect a `Timeout` error when awaiting an already completed task for `try_await`
- [x] Remove tests regarding awaiting an already completed task for `try_await_forever` (it will hang)
- [x] Manually tested: warning `Actor discarding unexpected message: DOWN` no longer occurs
- [x] Unit tests asserting that a completed task is unmonitored
- [x] Update `CHANGELOG.md`

I've unit tested this by checking the actor's mailbox using erlang's `process_info`.
There might be a more elegant way of doing this.