### PR TITLE
Fix: IntensityTracker properly returns error when limit is exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Fixed bug: supervisors now abort restarting children if limits are exceeded.
 - Fixed `gleam/otp/system.get_state/1` calls that break in Erlang/OTP >= 26.1.
   `get_state/1` (used in debugging and tests) will error on Erlang/OTP <=
   26.0 with "No case clause matched".

--- a/src/gleam/otp/intensity_tracker.gleam
+++ b/src/gleam/otp/intensity_tracker.gleam
@@ -3,7 +3,6 @@
 
 import gleam/list
 
-// TODO: test
 pub opaque type IntensityTracker {
   IntensityTracker(limit: Int, period: Int, events: List(Int))
 }
@@ -27,7 +26,7 @@ pub fn trim_window(events: List(Int), now: Int, period: Int) -> List(Int) {
   case events {
     [] -> []
     [event, ..events] ->
-      case now >= event + period {
+      case now < event + period {
         True -> [event, ..trim_window(events, now, period)]
         False -> []
       }
@@ -39,7 +38,7 @@ pub fn add_event(
 ) -> Result(IntensityTracker, TooIntense) {
   let now = now_seconds()
   let events = trim_window([now, ..tracker.events], now, tracker.period)
-  case list.length(events) >= tracker.limit {
+  case list.length(events) > tracker.limit {
     True -> Error(TooIntense)
     False -> Ok(IntensityTracker(..tracker, events: events))
   }

--- a/test/gleam/otp/intensity_tracker_test.gleam
+++ b/test/gleam/otp/intensity_tracker_test.gleam
@@ -17,8 +17,9 @@ pub fn errors_when_too_intense_test() {
 
 pub fn cools_down_after_period_test() {
   let count = 1000
-  let limiter = new(limit: count, period: 1)
-  |> add_events(count, _)
+  let limiter =
+    new(limit: count, period: 1)
+    |> add_events(count, _)
 
   // Since the intensity_tracker is enforced in seconds,
   // wait for that second to pass

--- a/test/gleam/otp/intensity_tracker_test.gleam
+++ b/test/gleam/otp/intensity_tracker_test.gleam
@@ -1,0 +1,41 @@
+import gleam/erlang/process
+import gleam/otp/intensity_tracker.{type IntensityTracker, add_event, new}
+import gleeunit
+import gleeunit/should
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn errors_when_too_intense_test() {
+  let count = 5
+  new(limit: count, period: 1)
+  |> add_events(count, _)
+  |> add_event()
+  |> should.be_error()
+}
+
+pub fn cools_down_after_period_test() {
+  let count = 1000
+  let limiter = new(limit: count, period: 1)
+  |> add_events(count, _)
+
+  // Since the intensity_tracker is enforced in seconds,
+  // wait for that second to pass
+  process.sleep(1000)
+  limiter
+  |> add_events(count, _)
+}
+
+fn add_events(count: Int, limiter: IntensityTracker) {
+  case count {
+    0 -> limiter
+    i if i > 0 -> {
+      limiter
+      |> add_event()
+      |> should.be_ok()
+      |> add_events(count - 1, _)
+    }
+    _ -> panic
+  }
+}


### PR DESCRIPTION
Summary: The IntensityTracker does not short-circuit due to a logic bug in recursion.

Expected behavior: If I set a limit of 5 restarts per minute, I expect six restarts to throw the error `TooIntense`

Actual behavior: The error does not throw, no matter how many times the supervisor restarts a child.

Explanation:

On the first event sent to the intensity_tracker:

`now == event`

So the subsequent logical check into recursion:

`now >= event + period`

always evaluated `False` given the default restart period. The event was always stripped from internal state, so the intensity_tracker never held more than one event at a time. The code in question:

https://github.com/gleam-lang/otp/blob/45deedf1fe9fead77d84b19cdf613cc6b41a3ae1/src/gleam/otp/intensity_tracker.gleam#L26-L35


This patch also includes tests for expected behavior. When testing, I discovered event maximum limit check was off by one, so this patch corrects and tests that edge case.

This was one of those pull-your-hair-out kind of bugs 🐛 Happy to make any changes!