### PR TITLE
fix: system message returned from GetState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Fixed `gleam/otp/system.get_state/1` calls that break in Erlang/OTP >= 26.1.
+  `get_state/1` (used in debugging and tests) will error on Erlang/OTP <=
+  26.0 with "No case clause matched".
+
 ## v0.9.0 - 2024-01-03
 
 - The useless `gleam_otp` module has been removed.

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -317,7 +317,7 @@ fn loop(self: Self(state, msg)) -> ExitReason {
     System(system) ->
       case system {
         GetState(callback) -> {
-          callback(Ok(dynamic.from(self.state)))
+          callback(dynamic.from(self.state))
           loop(self)
         }
         Resume(callback) -> {

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -317,7 +317,7 @@ fn loop(self: Self(state, msg)) -> ExitReason {
     System(system) ->
       case system {
         GetState(callback) -> {
-          callback(dynamic.from(self.state))
+          callback(Ok(dynamic.from(self.state)))
           loop(self)
         }
         Resume(callback) -> {

--- a/src/gleam/otp/system.gleam
+++ b/src/gleam/otp/system.gleam
@@ -44,7 +44,7 @@ pub type SystemMessage {
   // {debug, {remove, FuncOrId}}
   Resume(fn() -> Nil)
   Suspend(fn() -> Nil)
-  GetState(fn(Result(Dynamic, Nil)) -> Nil)
+  GetState(fn(Dynamic) -> Nil)
   GetStatus(fn(StatusInfo) -> Nil)
 }
 

--- a/src/gleam/otp/system.gleam
+++ b/src/gleam/otp/system.gleam
@@ -44,7 +44,7 @@ pub type SystemMessage {
   // {debug, {remove, FuncOrId}}
   Resume(fn() -> Nil)
   Suspend(fn() -> Nil)
-  GetState(fn(Dynamic) -> Nil)
+  GetState(fn(Result(Dynamic, Nil)) -> Nil)
   GetStatus(fn(StatusInfo) -> Nil)
 }
 
@@ -53,9 +53,13 @@ type DoNotLeak
 /// Get the state of a given OTP compatible process. This function is only
 /// intended for debugging.
 ///
-/// For more information see the [Erlang documentation][1].
+/// Requires Erlang/OTP 26.1 or newer, as the underlying interface changed
+/// in [OTP-18633][1] from a literal type to a result type.
 ///
-/// [1]: https://erlang.org/doc/man/sys.html#get_state-1
+/// For more information see the [Erlang documentation][2].
+///
+/// [1]: https://www.erlang.org/patches/otp-26.1#stdlib-5.1
+/// [2]: https://erlang.org/doc/man/sys.html#get_state-1
 ///
 @external(erlang, "sys", "get_state")
 pub fn get_state(from from: Pid) -> Dynamic

--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -25,7 +25,7 @@ convert_system_message({From, Ref}, Request) when is_pid(From) ->
     end,
     case Request of
         get_status -> System(fun(Status) -> Reply(process_status(Status)) end);
-        get_state -> System(Reply);
+        get_state -> System(fun(State) -> Reply({ok, State}) end);
         suspend -> System(fun() -> Reply(ok) end);
         resume -> System(fun() -> Reply(ok) end);
         Other -> {unexpeceted, Other}


### PR DESCRIPTION
Between Erlang/OTP 26.0 and 26.1, the interface for system messages changed from a literal type to result type, breaking our implementation. See [OTP-18633](https://www.erlang.org/patches/otp-26.1#stdlib-5.1) for more information.

This patch updates the library to 26.1, but sets a minimum version requirement. Since this is such a niche API (debugging only), we agreed that documentation is sufficient to enforce versions.

*Open Questions*
- [x] How descriptive do we need to be with the error type? Is `Nil` sufficient since we always respond with `Ok(state)`?


Tests pass locally, though some files need a reformat. Will address separately.

```
# Erlang/OTP 26.1

kdmb@nas ~/g/k/gleam_otp (fix/erlang_system_message_interface)> asdf current erlang
erlang          26.1.2          /home/kdmb/.tool-versions
kdmb@nas ~/g/k/gleam_otp (fix/erlang_system_message_interface)> gleam test
  Compiling gleam_otp
   Compiled in 0.34s
    Running gleam_otp_test.main
...............
Finished in 0.281 seconds
15 tests, 0 failures

# Erlang/OTP 26.2

kdmb@nas ~/g/k/gleam_otp (fix/erlang_system_message_interface)> asdf current erlang
erlang          26.2.1          /home/kdmb/.tool-versions
kdmb@nas ~/g/k/gleam_otp (fix/erlang_system_message_interface)> gleam test
   Compiled in 0.01s
    Running gleam_otp_test.main
...............
Finished in 0.282 seconds
15 tests, 0 failures
```
