### PR TITLE
Variable name type mismatch

### DIFF
--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -538,7 +538,7 @@ pub fn send(subject: Subject(msg), msg: msg) -> Nil {
 /// This is a re-export of `process.call`, for the sake of convenience.
 ///
 pub fn call(
-  selector: Subject(message),
+  subject: Subject(message),
   make_message: fn(Subject(reply)) -> message,
   timeout: Int,
 ) -> reply {


### PR DESCRIPTION
Should this function argument be called `subject`, since it's of type `Subject`?