### PR TITLE
Add Supervisor shutdown options

### DIFF
--- a/src/gleam/otp/supervisor.gleam
+++ b/src/gleam/otp/supervisor.gleam
@@ -40,7 +40,7 @@ pub opaque type ChildSpec(msg, argument, returning) {
     // TODO: merge this into one field
     start: fn(argument) -> Result(Subject(msg), StartError),
     returning: fn(argument, Subject(msg)) -> returning,
-    shutdown: Shutdown,
+    shutdown: ShutdownOptions,
   )
 }
 
@@ -58,7 +58,7 @@ type Instruction {
   StartFrom(Pid)
 }
 
-type Shutdown {
+type ShutdownOptions {
   BrutalKill
   Timeout(Int)
 }

--- a/src/gleam/otp/supervisor.gleam
+++ b/src/gleam/otp/supervisor.gleam
@@ -152,6 +152,8 @@ fn shutdown_child_brutal_kill(pid: Pid) {
   }
 }
 
+// We call unlink in order to guarantee that the 'EXIT' has arrived
+// from the dead process. See the [unlink](https://www.erlang.org/doc/apps/erts/erlang.html#unlink/1) docs for details.
 fn unlink_flush(pid) {
   process.unlink(pid)
   let result =

--- a/src/gleam/otp/supervisor.gleam
+++ b/src/gleam/otp/supervisor.gleam
@@ -1,4 +1,4 @@
-// TODO: specify amount of time permitted for shut-down
+import gleam/erlang/atom
 import gleam/erlang/node.{type Node}
 import gleam/erlang/process.{type Pid, type Subject}
 import gleam/option.{type Option, None, Some}
@@ -102,6 +102,9 @@ fn start_child(
   ))
 }
 
+@external(erlang, "erlang", "exit")
+fn erlang_exit(pid: Pid, reason: atom.Atom) -> Nil
+
 fn shutdown_child(pid: Pid, spec: ChildSpec(msg, arg_1, arg_2)) {
   case spec.shutdown {
     BrutalKill -> shutdown_child_brutal_kill(pid)
@@ -111,7 +114,7 @@ fn shutdown_child(pid: Pid, spec: ChildSpec(msg, arg_1, arg_2)) {
 
 fn shutdown_child_timeout(pid: Pid, timeout: Int) {
   let monitor = process.monitor_process(pid)
-  process.send_exit(pid)
+  erlang_exit(pid, atom.create_from_string("shutdown"))
 
   let result =
     process.new_selector()

--- a/src/gleam/otp/supervisor.gleam
+++ b/src/gleam/otp/supervisor.gleam
@@ -1,9 +1,6 @@
 // TODO: specify amount of time permitted for shut-down
-import gleam/dynamic
-import gleam/erlang/atom
 import gleam/erlang/node.{type Node}
 import gleam/erlang/process.{type Pid, type Subject}
-import gleam/io
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor.{type StartError}
 import gleam/otp/intensity_tracker.{type IntensityTracker}

--- a/test/gleam/otp/supervisor_test.gleam
+++ b/test/gleam/otp/supervisor_test.gleam
@@ -26,7 +26,6 @@ pub fn supervisor_test() {
   let child =
     child
     |> returning(fn(name, _subject) { name + 1 })
-    |> supervisor.shutdown_timeout(5)
 
   supervisor.start_spec(
     supervisor.Spec(


### PR DESCRIPTION
The original issue that I was facing was that supervisors never actually killed their child processes, thus leading to a memory/process leak when my system was running for about a week.

This pull request implements the two strategies that erlang's supervisor employees, timeout and brutal kill.

The root cause of why actors never exit with erlang:exit(pid, normal) is still unknown. 