### PR TITLE
Push Gleam version requirement to >= 1.1.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,7 @@ version = "0.12.0"
 licences = ["Apache-2.0"]
 description = "Fault tolerant multicore Gleam programs with OTP"
 
-gleam = ">= 0.32.0"
+gleam = ">= 1.1.0"
 
 repository = { type = "github", user = "gleam-lang", repo = "otp" }
 links = [


### PR DESCRIPTION
static_supervisor.gleam uses the `@internal` annotation, resulting in the following warning:

```
Incompatible gleam version range
This requires a Gleam version >= 1.1.0.
The `@internal` annotation was introduced in version v1.1.0. But the Gleam
version range specified in your `gleam.toml` would allow this code to run
on an earlier version like v0.32.0, resulting in compilation errors!
```