### PR TITLE
Remove gleam version constraint

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,8 +3,6 @@ version = "0.12.0"
 licences = ["Apache-2.0"]
 description = "Fault tolerant multicore Gleam programs with OTP"
 
-gleam = ">= 0.32.0"
-
 repository = { type = "github", user = "gleam-lang", repo = "otp" }
 links = [
   { title = "Website", href = "https://gleam.run" },


### PR DESCRIPTION
This fixes a warning coming from the compiler, the project uses the `@internal` annotation but would allow gleam versions below `1.1`. I removed the constraint altogether so the compiler will add the inferred one when published