### PR TITLE
Clarify when to use tasks vs processes in docs

### DIFF
--- a/src/gleam/otp/task.gleam
+++ b/src/gleam/otp/task.gleam
@@ -16,7 +16,8 @@
 //// There are some important things to consider when using tasks:
 ////
 //// 1. If you are using async tasks, you must await a reply as they are always
-////    sent.
+////    sent. If you do not need a reply from an async operation, look at using 
+////    the `gleam/erlang/process` module's `start` function instead.
 ////
 //// 2. Tasks link the caller and the spawned process. This means that,
 ////    if the caller crashes, the task will crash too and vice-versa. This is


### PR DESCRIPTION
Totally up to the maintainers if they want to merge this, but a note like this would've saved me some time: I was focusing entirely on the `gleam/erlang/otp` package to manage concurrency and needed to run a concurrent one-shot task with side effects but no return value. The task module (great module btw) was the only thing in this package that provided one-shot concurrent processing, so I tried to do a bunch of hackery to not await the return. A little while later I was reading some Gleam code and realized the simpler `gleam/erlang/process.start` was what I needed all along. Since the rest of my concurrency was handled using otp, I didn't think to reach to the more lower level erlang package. I know this is just a skill issue, but a note like this in the docs might nudge newer users of OTP to look into the underlying erlang primitives more when needed.