### PR TITLE
Fix doc and add child spec

### DIFF
--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -1,7 +1,7 @@
 //// This module provides the _Actor_ abstraction, one of the most common
 //// building blocks of Gleam OTP programs.
 //// 
-//// An Actor is a process like any other BEAM process and can be be used to hold
+//// An Actor is a process like any other BEAM process and can be used to hold
 //// state, execute code, and communicate with other processes by sending and
 //// receiving messages. The advantage of using the actor abstraction over a bare
 //// process is that it provides a single interface for commonly needed

--- a/src/gleam/otp/static_supervisor.gleam
+++ b/src/gleam/otp/static_supervisor.gleam
@@ -286,6 +286,7 @@ fn convert_child(child: ChildBuilder) -> Dict(Atom, Dynamic) {
   |> property("id", child.id)
   |> property("start", mfa)
   |> property("restart", child.restart)
+  |> property("significant", child.significant)
   |> property("type", type_)
   |> property("shutdown", shutdown)
 }


### PR DESCRIPTION
I am in the process of learning how the `static_supervisor` works, and I noticed that the `significant` property wasn't added to the `convert_child`. According to the Erlang [documentation](https://www.erlang.org/doc/apps/stdlib/supervisor#module-child-specification): 

```erlang
child_spec() = #{id => child_id(),             % mandatory
                 start => mfargs(),            % mandatory
                 restart => restart(),         % optional
                 significant => significant(), % optional
                 shutdown => shutdown(),       % optional
                 type => worker(),             % optional
                 modules => modules()}         % optional
```

We should be able to pass the ChildBuilder.significant to the `convert_child` which then will be passed to the `supervisor:start_link`. 

Example of how the significant spec gets passed to running `worker_child`

```
    offender: [{pid,<0.864.0>},
               {id,<<"worker">>},
               {mfargs,{erlang,apply,
                               [#Fun<gleam@otp@static_supervisor.0.87899615>,
                                []]}},
               {restart_type,temporary},
               {significant,true},
               {shutdown,5000},
               {child_type,worker}]
```