### PR TITLE
Implementation of the exit_process for Actor

### DIFF
--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -1,7 +1,7 @@
 //// This module provides the _Actor_ abstraction, one of the most common
 //// building blocks of Gleam OTP programs.
 //// 
-//// An Actor is a process like any other BEAM process and can be be used to hold
+//// An Actor is a process like any other BEAM process and can be used to hold
 //// state, execute code, and communicate with other processes by sending and
 //// receiving messages. The advantage of using the actor abstraction over a bare
 //// process is that it provides a single interface for commonly needed

--- a/src/gleam/otp/static_supervisor.gleam
+++ b/src/gleam/otp/static_supervisor.gleam
@@ -286,6 +286,7 @@ fn convert_child(child: ChildBuilder) -> Dict(Atom, Dynamic) {
   |> property("id", child.id)
   |> property("start", mfa)
   |> property("restart", child.restart)
+  |> property("significant", child.significant)
   |> property("type", type_)
   |> property("shutdown", shutdown)
 }


### PR DESCRIPTION
### Context

In my journey of learning how the OTP works, when I tried to send an exit signal to an Actor I noticed that the `exit_process` wasn't fully implemented. So, I tried to give it a try and implement it based on:

- https://erlang.org/documentation/doc-4.9.1/doc/design_principles/sup_princ.html#shutdown
- https://www.erlang.org/doc/apps/erts/erlang#exit/2
- https://erlang.org/pipermail/erlang-questions/2005-April/014993.html

Apologies in advance if this isn't the correct way of implementing the Shutdown protocol. I will be more than happy to amend the PR with a more correct Shutdown protocol based on the received feedback.

### Changes

- linting on the `otp/actor.gleam` (I can move this to a separate PR, if necessary).
- `exit_process` now supports Normal, Killed and Abnormal exit reasons.
- fix the broken `failed_init_test`: this test was blocking the whole actor test from running due to an unhandled crash.

```
  Compiling gleam_otp
   Compiled in 0.29s
    Running gleam_otp_test.main
....
Pending:
  undefined
    %% Related process exited with reason: {abnormal,<<"not enough wiggles">>}
```

- tests for the `exit_process` implementation: this covers the Normal, Killed and Abnormal reasons.