### PR TITLE
Make `actor.Stop` respect the given exit reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Fixed a bug where using `actor.Stop(process.Abnormal(...))` would stop
-  the process with `Normal`.
+- Fixed a bug where using `actor.Stop()` with other reasons than `Normal`
+  would stop the process with `Normal`.
 
 ## v0.16.1 - 2025-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug where using `actor.Stop(process.Abnormal(...))` would stop
+  the process with `Normal`.
+
 ## v0.16.1 - 2025-01-20
 
 - Fixed a bug where the static supervisor would return the incorrect value if

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -139,7 +139,7 @@ import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
 import gleam/erlang/process.{
-  type ExitReason, type Pid, type Selector, type Subject, Abnormal,
+  type ExitReason, type Pid, type Selector, type Subject, Abnormal, Killed,
 }
 import gleam/option.{type Option, None, Some}
 import gleam/otp/system.{
@@ -259,10 +259,10 @@ pub type Spec(state, msg) {
 fn exit_process(reason: ExitReason) -> ExitReason {
   case reason {
     Abnormal(reason) -> process.send_abnormal_exit(process.self(), reason)
+    Killed -> process.kill(process.self())
     _ -> Nil
   }
 
-  // TODO
   reason
 }
 
@@ -409,7 +409,7 @@ fn initialise_actor(
       loop(self)
     }
 
-    // The init failed. Exit with an error.
+    // The init failed. Send the reason back to the parent, but exit normally.
     Failed(reason) -> {
       process.send(ack, Error(Abnormal(reason)))
       exit_process(process.Normal)

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -189,7 +189,7 @@ pub fn with_selector(
 ) -> Next(message, state) {
   case value {
     Continue(state, _) -> Continue(state, Some(selector))
-    _ -> value
+    Stop(_) -> value
   }
 }
 

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -257,6 +257,11 @@ pub type Spec(state, msg) {
 
 // TODO: Check needed functionality here to be OTP compatible
 fn exit_process(reason: ExitReason) -> ExitReason {
+  case reason {
+    Abnormal(reason) -> process.send_abnormal_exit(process.self(), reason)
+    _ -> Nil
+  }
+
   // TODO
   reason
 }
@@ -407,7 +412,7 @@ fn initialise_actor(
     // The init failed. Exit with an error.
     Failed(reason) -> {
       process.send(ack, Error(Abnormal(reason)))
-      exit_process(Abnormal(reason))
+      exit_process(process.Normal)
     }
   }
 }

--- a/test/gleam/otp/actor_test.gleam
+++ b/test/gleam/otp/actor_test.gleam
@@ -231,6 +231,31 @@ pub fn replace_selector_test() {
   |> should.equal(dynamic.from("unknown message: String"))
 }
 
+pub fn abnormal_exit_can_be_trapped_test() {
+  process.trap_exits(True)
+  let exits =
+    process.new_selector()
+    |> process.selecting_trapped_exits(function.identity)
+
+  // Make an actor exit with an abnormal reason
+  let assert Ok(subject) =
+    actor.start(Nil, fn(_, _) { actor.Stop(process.Abnormal("reason")) })
+  process.send(subject, Nil)
+
+  let trapped_reason = process.select(exits, 10)
+
+  // Stop trapping exits, as otherwise other tests fail
+  process.trap_exits(False)
+
+  trapped_reason
+  |> should.equal(
+    Ok(process.ExitMessage(
+      process.subject_owner(subject),
+      process.Abnormal("reason"),
+    )),
+  )
+}
+
 fn mapped_selector(mapper: fn(a) -> ActorMessage) {
   let subject = process.new_subject()
 

--- a/test/gleam/otp/actor_test.gleam
+++ b/test/gleam/otp/actor_test.gleam
@@ -256,6 +256,28 @@ pub fn abnormal_exit_can_be_trapped_test() {
   )
 }
 
+pub fn killed_exit_can_be_trapped_test() {
+  process.trap_exits(True)
+  let exits =
+    process.new_selector()
+    |> process.selecting_trapped_exits(function.identity)
+
+  // Make an actor exit with a killed reason
+  let assert Ok(subject) =
+    actor.start(Nil, fn(_, _) { actor.Stop(process.Killed) })
+  process.send(subject, Nil)
+
+  let trapped_reason = process.select(exits, 10)
+
+  // Stop trapping exits, as otherwise other tests fail
+  process.trap_exits(False)
+
+  trapped_reason
+  |> should.equal(
+    Ok(process.ExitMessage(process.subject_owner(subject), process.Killed)),
+  )
+}
+
 fn mapped_selector(mapper: fn(a) -> ActorMessage) {
   let subject = process.new_subject()
 

--- a/test/gleam/otp/actor_test.gleam
+++ b/test/gleam/otp/actor_test.gleam
@@ -247,11 +247,12 @@ pub fn abnormal_exit_can_be_trapped_test() {
   // Stop trapping exits, as otherwise other tests fail
   process.trap_exits(False)
 
+  // The weird reason below is because of https://github.com/gleam-lang/erlang/issues/66
   trapped_reason
   |> should.equal(
     Ok(process.ExitMessage(
       process.subject_owner(subject),
-      process.Abnormal("reason"),
+      process.Abnormal("Abnormal(\"reason\")"),
     )),
   )
 }


### PR DESCRIPTION
Resolves #89

The actor would stop with `Normal` before this.