### PR TITLE
Fix actor init timeout sending exit message to linked parent

### DIFF
--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -489,6 +489,9 @@ pub fn start_spec(spec: Spec(state, msg)) -> Result(Subject(msg), StartError) {
 
     // Child did not finish initialising in time
     Error(Nil) -> {
+      // Unlink the child before killing it, so that we only return the error,
+      // but don't also send an exit message to the linked parent process.
+      process.unlink(child)
       process.kill(child)
       Error(InitTimeout)
     }


### PR DESCRIPTION
Resolves #73

In addition to returning an error, a timed out actor init would also propagate the exit message to the parent process, causing it to get killed unless it was trapping exits.