### PR TITLE
fix: return error when supervisor:start_link/2 fails

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "gleam_otp"
-version = "0.16.0"
+version = "0.16.1"
 licences = ["Apache-2.0"]
 description = "Fault tolerant multicore Gleam programs with OTP"
 

--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -48,5 +48,5 @@ application_stopped() ->
 static_supervisor_start_link(Arg) ->
     case supervisor:start_link(gleam@otp@static_supervisor, Arg) of
         {ok, P} -> {ok, P};
-        {error, E} -> {ok, {init_crashed, E}}
+        {error, E} -> {error, {init_crashed, E}}
     end.


### PR DESCRIPTION
closes #94 