### PR TITLE
Make observer status printout pretty

### DIFF
--- a/src/gleam_otp_external.erl
+++ b/src/gleam_otp_external.erl
@@ -43,12 +43,17 @@ convert_system_message({system, {From, Ref}, Request}) when is_pid(From) ->
     end.
 
 process_status({status_info, Module, Parent, Mode, DebugState, State}) ->
-    Data = [
-        get(), Mode, Parent, DebugState,
-        [{header, "Status for Gleam process " ++ pid_to_list(self())},
-         {data, [{'Status', Mode}, {'Parent', Parent}, {'State', State}]}]
-    ],
-    {status, self(), {module, Module}, Data}.
+     Data = [
+         get(), Mode, Parent, DebugState,
+         [{header, "Status for Gleam process " ++ pid_to_list(self())},
+           {data, [
+             {"Gleam behaviour", Module},
+             {"Status", Mode},
+             {"Parent", Parent}]},
+          {data, [{"State", State}]}
+         ]
+     ],
+     {status, self(), {module, Module}, Data}.
 
 application_stopped() ->
     ok.


### PR DESCRIPTION
This will give the observer status printout:
![status2](https://github.com/user-attachments/assets/d0045fa0-6214-4abb-a64e-c775b573fd34)
as compared to the current:
![status1](https://github.com/user-attachments/assets/2d4d69b1-1449-4ec2-86ba-5b2b5d752d54)
