### PR TITLE
Add actor stop reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `actor` module gains a `stop_abnormal` method
+
 ## v1.0.0-rc1 - 2025-05-16
 
 - The `supervisor` module has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- The `actor` module gains a `stop_abnormal` method
+- The `actor` module gains a `stop_abnormal` function
 
 ## v1.0.0-rc1 - 2025-05-16
 

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -194,6 +194,15 @@ pub fn stop() -> Next(state, message) {
   Stop(process.Normal)
 }
 
+/// Indicate the actor is in a bad state and should shut down. It will not
+/// handle any new messages, and any linked processes will also exit abnormally.
+///
+/// The provided reason will be given and propagated.
+///
+pub fn stop_abnormal(reason: Dynamic) -> Next(state, message) {
+  Stop(process.Abnormal(reason))
+}
+
 /// Provide a selector to change the messages that the actor is handling
 /// going forward. This replaces any selector that was previously given
 /// in the actor's `init` callback, or in any previous `Next` value.

--- a/test/gleam/otp/actor_test.gleam
+++ b/test/gleam/otp/actor_test.gleam
@@ -265,6 +265,7 @@ pub fn abnormal_exit_can_be_trapped_test() {
   // Stop trapping exits, as otherwise other tests fail
   process.trap_exits(False)
 
+  // The weird reason below is because of https://github.com/gleam-lang/erlang/issues/66
   trapped_reason
   |> should.equal(
     Ok(process.ExitMessage(actor.pid, process.Abnormal(dynamic.from("boo!")))),
@@ -312,6 +313,7 @@ pub fn abnormal_stop_exits_linked_test() {
   // Stop trapping exits, as otherwise other tests fail
   process.trap_exits(False)
 
+  // The weird reason below is because of https://github.com/gleam-lang/erlang/issues/66
   trapped_reason
   |> should.equal(
     Ok(process.ExitMessage(actor.pid, process.Abnormal(dynamic.from("wibble")))),


### PR DESCRIPTION
Currently, there is only a `stop()` method to exit normally.  This PR adds the ability to pass a `Dynamic` reason to exit with.