### PR TITLE
Bump stdlib requirement to 0.60

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = ">= 0.59.0 and < 2.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0-rc1 and < 2.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
0.59 results in compiler errors:
```
error: Type mismatch
    ┌─ /.../build/packages/gleam_otp/src/gleam/otp/actor.gleam:203:25
    │
203 │   Stop(process.Abnormal(dynamic.string(reason)))
    │                         ^^^^^^^^^^^^^^^^^^^^^^

Expected type:

    Dynamic

Found type:

    Result(String, List(dynamic.DecodeError))
```