### PR TITLE
Added `actor.set_timeout` function and improved documentation for `actor.start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v1.1.1 - 2025-08-06
 
 - Updated `actor.start` documentation to reflect current use case.
-- Added `actor.set_timeout` function for setting `Builder` timeout.
 
 ## v1.1.0 - 2025-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.1 - 2025-08-06
 
 - Updated `actor.start` documentation to reflect current use case.
+- Added `actor.set_timeout` function for setting `Builder` timeout.
 
 ## v1.1.0 - 2025-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.1 - 2025-08-06
+
+- Updated `actor.start` documentation to reflect current use case.
+
 ## v1.1.0 - 2025-08-05
 
 - The `call` function in the `gleam/otp/actor` module gains the labels

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -373,7 +373,7 @@ pub fn new_with_initialiser(
 /// an error.
 pub fn set_timeout(
   timeout: Int,
-  builder: Builder(state, message, return)
+  builder: Builder(state, message, return),
 ) -> Builder(state, message, return) {
   Builder(..builder, initialisation_timeout: timeout)
 }

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -368,6 +368,16 @@ pub fn new_with_initialiser(
   )
 }
 
+/// Set the timeout for a `Builder` in milliseconds. This timeout value
+/// determines how long the actor should await intitialisation before returning 
+/// an error.
+pub fn set_timeout(
+  timeout: Int,
+  builder: Builder(state, message, return)
+) -> Builder(state, message, return) {
+  Builder(..builder, initialisation_timeout: timeout)
+}
+
 /// Set the message handler for the actor. This callback function will be
 /// called each time the actor receives a message.
 ///

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -588,13 +588,7 @@ type StartInitMessage(data) {
   Mon(process.Down)
 }
 
-/// Start an actor from a given specification. If the actor's `init` function
-/// returns an error or does not return within `init_timeout` then an error is
-/// returned.
-///
-/// If you do not need to specify the initialisation behaviour of your actor
-/// consider using the `start` function.
-///
+/// Starts an actor from a given `Builder`. On failure, `start` returns a `StartError`
 pub fn start(
   builder: Builder(state, msg, return),
 ) -> Result(Started(return), StartError) {

--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -368,16 +368,6 @@ pub fn new_with_initialiser(
   )
 }
 
-/// Set the timeout for a `Builder` in milliseconds. This timeout value
-/// determines how long the actor should await intitialisation before returning 
-/// an error.
-pub fn set_timeout(
-  timeout: Int,
-  builder: Builder(state, message, return),
-) -> Builder(state, message, return) {
-  Builder(..builder, initialisation_timeout: timeout)
-}
-
 /// Set the message handler for the actor. This callback function will be
 /// called each time the actor receives a message.
 ///


### PR DESCRIPTION
This PR hopes to resolve #108 and improve the documentation for `actor.start`

Additionally, I added the missing `actor.set_timeout` to the library, as brought to light by @lpil in the same issue.