### PR TITLE
fix typo and grammar in docs

### DIFF
--- a/src/gleam/otp/actor.gleam
+++ b/src/gleam/otp/actor.gleam
@@ -104,7 +104,7 @@
 ////   case message {
 ////     // For the `Shutdown` message we return the `actor.stop` value, which causes
 ////     // the actor to discard any remaining messages and stop.
-////     // We may chose to do some clean-up work here, but this actor doesn't need
+////     // We may choose to do some clean-up work here, but this actor doesn't need
 ////     // to do this.
 ////     Shutdown -> actor.stop()
 //// 
@@ -348,7 +348,7 @@ pub fn new(state: state) -> Builder(state, message, Subject(message)) {
 /// will be returned to the parent.
 ///
 /// The actor's default subject is passed to the initialiser function. You can
-/// chose to return it to the parent with `returning`, use it in some other
+/// choose to return it to the parent with `returning`, use it in some other
 /// way, or ignore it completely.
 ///
 /// If a custom selector is given using the `selecting` function then this

--- a/src/gleam/otp/factory_supervisor.gleam
+++ b/src/gleam/otp/factory_supervisor.gleam
@@ -378,7 +378,7 @@ fn make_timeout(amount: Int) -> Timeout
 
 /// Create a `ChildSpecification` that adds this supervisor as the child of
 /// another, making it fault tolerant and part of the application's supervision
-/// tree. You should prefer to starting unsupervised supervisors with the
+/// tree. You should prefer this to starting unsupervised supervisors with the
 /// `start` function.
 ///
 /// If any child fails to start the supervisor first terminates all already

--- a/src/gleam/otp/static_supervisor.gleam
+++ b/src/gleam/otp/static_supervisor.gleam
@@ -178,7 +178,7 @@ pub fn start(
 
 /// Create a `ChildSpecification` that adds this supervisor as the child of
 /// another, making it fault tolerant and part of the application's supervision
-/// tree. You should prefer to starting unsupervised supervisors with the
+/// tree. You should prefer this to starting unsupervised supervisors with the
 /// `start` function.
 ///
 /// If any child fails to start the supervisor first terminates all already

--- a/test/gleam/otp/actor_documentation_example_test.gleam
+++ b/test/gleam/otp/actor_documentation_example_test.gleam
@@ -82,7 +82,7 @@ fn handle_message(
   case message {
     // For the `Shutdown` message we return the `actor.stop` value, which causes
     // the actor to discard any remaining messages and stop.
-    // We may chose to do some clean-up work here, but this actor doesn't need
+    // We may choose to do some clean-up work here, but this actor doesn't need
     // to do this.
     Shutdown -> actor.stop()
 


### PR DESCRIPTION
Thank you for the wonderful library 🙏 . As I was reading the docs came across a few minor typos / grammar errors.

Fixes https://github.com/gleam-lang/otp/issues/127